### PR TITLE
Fix token refresh: accept numeric userid from Withings

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -178,7 +178,7 @@ func exchangeCode(code, redirectURI, clientID, clientSecret string) error {
 		AccessToken:  resp.AccessToken,
 		RefreshToken: resp.RefreshToken,
 		ExpiresAt:    time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second).Add(-5 * time.Minute),
-		UserID:       resp.UserID,
+		UserID:       resp.UserID.String(),
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 	}
@@ -201,19 +201,19 @@ func refresh(store *TokenStore) error {
 	store.AccessToken = resp.AccessToken
 	store.RefreshToken = resp.RefreshToken
 	store.ExpiresAt = time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second).Add(-5 * time.Minute)
-	if resp.UserID != "" {
-		store.UserID = resp.UserID
+	if resp.UserID.String() != "" {
+		store.UserID = resp.UserID.String()
 	}
 	return save(store)
 }
 
 type tokenResponse struct {
-	UserID       string `json:"userid"`
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	ExpiresIn    int    `json:"expires_in"`
-	Scope        string `json:"scope"`
-	TokenType    string `json:"token_type"`
+	UserID       json.Number `json:"userid"`
+	AccessToken  string      `json:"access_token"`
+	RefreshToken string      `json:"refresh_token"`
+	ExpiresIn    int         `json:"expires_in"`
+	Scope        string      `json:"scope"`
+	TokenType    string      `json:"token_type"`
 }
 
 func postToken(form url.Values, out *tokenResponse) error {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Withings returns userid as a JSON string on the initial authorization_code
+// grant and as a JSON number on the refresh_token grant. tokenResponse.UserID
+// must unmarshal both without error — json.Number accepts either form.
+func TestTokenResponse_UserIDUnmarshalsStringAndNumber(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"string form (initial login)", `{"userid":"12345","access_token":"a","refresh_token":"r","expires_in":10800,"scope":"s","token_type":"Bearer"}`},
+		{"number form (refresh)", `{"userid":12345,"access_token":"a","refresh_token":"r","expires_in":10800,"scope":"s","token_type":"Bearer"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp tokenResponse
+			if err := json.Unmarshal([]byte(tc.body), &resp); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if resp.UserID.String() != "12345" {
+				t.Fatalf("UserID = %q, want %q", resp.UserID.String(), "12345")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Withings `/v2/oauth2` returns `userid` as a JSON **string** on the `authorization_code` grant but as a JSON **number** on the `refresh_token` grant. `tokenResponse.UserID` was typed `string`, so every refresh failed with `cannot unmarshal number into Go struct field tokenResponse.userid of type string`, locking users out ~3h after login until they re-ran `auth login`.
- Switch the field to `json.Number` (unmarshals from either form); call `.String()` at the two assign sites.
- `TokenStore.UserID` remains `string` on disk — existing `auth.json` files stay valid.
- Adds a regression test covering both wire forms.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/auth/...` — both subtests pass
- [x] Manual: force-expire token (`expires_at` → 2020), run `measurements --since 1d --json`, confirm refresh succeeds and new `expires_at` is ~3h out

🤖 Generated with [Claude Code](https://claude.com/claude-code)