### PR TITLE
fix: resolve dates and display timestamps in local time

### DIFF
--- a/cmd/intraday.go
+++ b/cmd/intraday.go
@@ -129,7 +129,7 @@ func writeIntradayCSV(samples []intradaySample) error {
 	w := csv.NewWriter(os.Stdout)
 	defer w.Flush()
 	header := []string{
-		"timestamp", "datetime_utc", "duration_sec",
+		"timestamp", "datetime", "duration_sec",
 		"steps", "distance_m", "elevation_m", "calories",
 		"heart_rate", "hrv_rmssd", "hrv_sdnn1", "hrv_quality", "spo2_auto",
 		"model", "model_id",
@@ -140,7 +140,7 @@ func writeIntradayCSV(samples []intradaySample) error {
 	for _, s := range samples {
 		row := []string{
 			strconv.FormatInt(s.Timestamp, 10),
-			time.Unix(s.Timestamp, 0).UTC().Format(time.RFC3339),
+			time.Unix(s.Timestamp, 0).Local().Format(time.RFC3339),
 			strconv.Itoa(s.Duration),
 			strconv.Itoa(s.Steps),
 			strconv.FormatFloat(s.Distance, 'f', -1, 64),

--- a/cmd/measurements.go
+++ b/cmd/measurements.go
@@ -101,7 +101,7 @@ var measurementsCmd = &cobra.Command{
 				return err
 			}
 			for _, g := range resp.Measuregrps {
-				t := time.Unix(g.Date, 0).UTC()
+				t := time.Unix(g.Date, 0).Local()
 				for _, m := range g.Measures {
 					value := float64(m.Value) * math.Pow10(m.Unit)
 					name, ok := measureTypeNames[m.Type]

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -13,7 +13,7 @@ func parseSince(s string) (time.Time, error) {
 	if s == "" {
 		return time.Time{}, nil
 	}
-	if t, err := time.Parse("2006-01-02", s); err == nil {
+	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
 		return t, nil
 	}
 	if len(s) < 2 {

--- a/cmd/sleep.go
+++ b/cmd/sleep.go
@@ -302,8 +302,8 @@ func writeSleepCSV(series []sleepSeries) error {
 		}
 		_ = json.Unmarshal(s.Data, &d)
 
-		start := time.Unix(s.StartDate, 0).UTC()
-		end := time.Unix(s.EndDate, 0).UTC()
+		start := time.Unix(s.StartDate, 0).Local()
+		end := time.Unix(s.EndDate, 0).Local()
 		totalSleepMin := (d.Light + d.Deep + d.REM) / 60
 
 		row := []string{

--- a/cmd/workouts.go
+++ b/cmd/workouts.go
@@ -163,8 +163,8 @@ func writeWorkoutsCSV(series []workoutSeries) error {
 		}
 		_ = json.Unmarshal(s.Data, &d)
 
-		start := time.Unix(s.StartDate, 0).UTC()
-		end := time.Unix(s.EndDate, 0).UTC()
+		start := time.Unix(s.StartDate, 0).Local()
+		end := time.Unix(s.EndDate, 0).Local()
 		category := workoutCategoryNames[s.Category]
 		if category == "" {
 			category = "unknown"


### PR DESCRIPTION
## Summary

Applies the same timezone-policy fix landed in [crono-export-cli#5](https://github.com/quantcli/crono-export-cli/pull/5) and [liftoff-export-cli#14](https://github.com/quantcli/liftoff-export-cli/pull/14). Two bug classes, both silent off-by-tz-offset errors for any user not running in UTC:

1. **\`parseSince\` parsed absolute dates as UTC.** \`cmd/shared.go:16\` used bare \`time.Parse\`, which defaults to UTC. Downstream, \`measurements.go:90\` feeds \`since.Unix()\` to the Withings API \`startdate\` param — so \`--since 2026-04-15\` in EDT asked the API for data from \`2026-04-14 20:00 EDT\` onward, quietly including 4 hours of the previous calendar day. Fixed: \`time.ParseInLocation(..., time.Local)\`.
2. **Display-side \`.UTC()\` on Unix timestamps.** \`sleep.go:305-306\`, \`workouts.go:166-167\`, \`measurements.go:104\`, \`intraday.go:143\` all rendered timestamps as UTC regardless of the user's zone. A 10:30pm PST sleep session showed as \`06:30Z\` the next day in the CSV. Fixed: \`.Local()\` everywhere. Intraday CSV column renamed \`datetime_utc\` → \`datetime\` to match.

JSON output for struct fields that ride Go's default \`time.Time\` marshaler is unchanged in spirit (still RFC3339 with offset — just now the offset is the user's local one). Unix-epoch int64 fields were never timezone-dependent.

## Test plan

- [x] \`go build ./...\` and \`go vet ./...\` pass
- [x] \`go test ./...\` passes (no cmd-level tests exist; auth package test still green)
- [ ] Reviewer: confirm \`measurements --since <yesterday>\` no longer returns measurements from the day before
- [ ] Reviewer: confirm sleep/workout/intraday CSV times now render in your local zone

🤖 Generated with [Claude Code](https://claude.com/claude-code)