### PR TITLE
feat: add 'auth status' subcommand

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/quantcli/withings-export-cli/internal/auth"
 	"github.com/spf13/cobra"
@@ -84,8 +85,35 @@ var refreshCmd = &cobra.Command{
 	},
 }
 
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print one-line auth readiness state and exit 0 if usable",
+	Long: `Print a one-line summary of whether the CLI has a usable token. Exit 0
+if a saved token is present and not yet expired, 1 otherwise.
+
+This is a local check — no network call and no refresh is attempted, even
+when the saved token is expired. Use 'auth refresh' (or any export
+subcommand) to actually refresh.
+
+Per the quantcli shared contract:
+https://github.com/quantcli/common/blob/main/CONTRACT.md#5-auth`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		store, err := auth.Load()
+		if err != nil {
+			return fmt.Errorf("not logged in — run: withings-export auth login")
+		}
+		exp := store.ExpiresAt.Local().Format(time.RFC3339)
+		if time.Now().After(store.ExpiresAt) {
+			return fmt.Errorf("token expired %s — run: withings-export auth refresh", exp)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "logged in as user %s (token expires %s)\n", store.UserID, exp)
+		return nil
+	},
+}
+
 func init() {
 	authCmd.AddCommand(loginCmd)
 	authCmd.AddCommand(logoutCmd)
 	authCmd.AddCommand(refreshCmd)
+	authCmd.AddCommand(statusCmd)
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -267,6 +267,13 @@ func load() (*TokenStore, error) {
 	return &store, nil
 }
 
+// Load reads the saved token store without attempting a refresh. Returns
+// (nil, error) when no token has been saved yet. Suitable for non-mutating
+// status checks; use GetToken when an action needs a usable access token.
+func Load() (*TokenStore, error) {
+	return load()
+}
+
 func openBrowser(target string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {


### PR DESCRIPTION
## Summary

Per [CONTRACT §5](https://github.com/quantcli/common/blob/main/CONTRACT.md#5-auth), every quantcli CLI exposes \`auth status\` printing a one-line readiness summary, exit 0 if usable.

\`\`\`
$ withings-export auth status
logged in as user 1629692 (token expires 2026-04-25T20:24:22-04:00)
$ echo \$?
0
\`\`\`

Three states:

| Condition | Output | Exit |
|---|---|---|
| Token saved, unexpired | \`logged in as user X (token expires …)\` | 0 |
| No saved token | \`not logged in — run: withings-export auth login\` | 1 |
| Saved token, expired | \`token expired … — run: withings-export auth refresh\` | 1 |

Local check only — no network call. Adds exported \`auth.Load()\` so \`cmd/\` can read the token store without going through \`GetToken\`'s auto-refresh path. Reports the Withings numeric user ID (\`UserID\` is what the OAuth flow actually persists; we don't store the email).

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` pass
- [x] Logged-in state returns exit 0 with user ID + expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)