### PR TITLE
fix: emit [] for empty JSON; correct workouts category prime note

### DIFF
--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -135,9 +135,11 @@ GOTCHAS
     (250ms between calls); ad-hoc loops should do the same.
   - Sleep score and apnea fields are populated only on supported devices.
     'data.sleep_score' is null on unsupported wakeup-light models.
-  - 'workouts' category codes are integers; common ones are mapped to
-    string names (walk/run/bicycling/...) but unknown codes pass through
-    as 'unknown' with the numeric category_code preserved.
+  - 'workouts' category is a Withings integer code in JSON (1=walk,
+    2=run, 6=bicycling, 16=lift_weights, ...).  Markdown and CSV map
+    common codes to string names ('lift_weights', 'walk', ...) and
+    unknown codes render as 'unknown'; CSV also keeps the raw integer
+    in a 'category_code' column.
 `
 
 var primeCmd = &cobra.Command{

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -108,6 +109,12 @@ func untilDayOrToday(s string) (time.Time, error) {
 }
 
 func printJSON(v any) error {
+	// A nil slice marshals as "null"; force "[]" so empty windows match the
+	// prime contract (and don't blow up jq pipelines).
+	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Slice && rv.IsNil() {
+		_, err := os.Stdout.WriteString("[]\n")
+		return err
+	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(v); err != nil {


### PR DESCRIPTION
## Summary
Two fixes exposed while writing the `prime` subcommand (#10):

- **All five subcommands emitted `null` for empty `--format json` windows** (the underlying nil slice). The prime promises `[]`, and `null` also breaks the prime's sleep-efficiency jq example. `printJSON` now special-cases nil slices.
- **The workouts prime gotcha implied JSON carried both a string `category` and a numeric `category_code`.** JSON actually carries only the integer `category` (string mapping happens in markdown/CSV, and CSV alone keeps the raw int as `category_code`). Rewrote the gotcha to describe actual behavior and list common code values inline so an LLM can filter by `category == 16` without round-tripping.

## Test plan
- [x] Empty `--format json` for every subcommand (`sleep`/`activity`/`workouts`/`measurements`/`intraday`) emits `[]`, not `null`.
- [x] `workouts --format csv` still includes both `category` (string) and `category_code` (int) columns.
- [x] `withings-export prime` reflects the corrected workouts note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)