### PR TITLE
fix: exit non-zero and print help to stderr for bare auth/root invocations

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -12,8 +12,14 @@ import (
 )
 
 var authCmd = &cobra.Command{
-	Use:   "auth",
-	Short: "Authentication commands",
+	Use:          "auth",
+	Short:        "Authentication commands",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SetOut(cmd.ErrOrStderr())
+		_ = cmd.Help()
+		return fmt.Errorf("subcommand required")
+	},
 }
 
 var loginCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,16 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "withings-export",
-	Short: "CLI to export health data from Withings",
+	Use:          "withings-export",
+	Short:        "CLI to export health data from Withings",
+	SilenceUsage: true,
 	Long: `withings-export reads your personal Withings health data — activity,
 sleep, workouts, body measurements, intraday samples — and prints it on
 stdout. Default output is narrow, fitdown-style markdown; pass
@@ -16,6 +18,11 @@ stdout. Default output is narrow, fitdown-style markdown; pass
 
 LLM agents: run 'withings-export prime' for a one-screen orientation
 (I/O contract, subcommands, date flags, jq recipes).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SetOut(cmd.ErrOrStderr())
+		_ = cmd.Help()
+		return fmt.Errorf("subcommand required")
+	},
 }
 
 func Execute() {


### PR DESCRIPTION
Bare `withings-export auth` and `withings-export` (no subcommand) previously printed help to stdout and exited 0, polluting stdout for shell-script consumers. Now both commands print help to stderr and return exit code 1 when no subcommand is given.

Closes #28

Generated with [Claude Code](https://claude.ai/code)