### PR TITLE
fix: reject unknown subcommands on auth command with exit non-zero

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -14,6 +14,7 @@ import (
 var authCmd = &cobra.Command{
 	Use:          "auth",
 	Short:        "Authentication commands",
+	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SetOut(cmd.ErrOrStderr())


### PR DESCRIPTION
Adds `Args: cobra.NoArgs` to `authCmd` in `cmd/auth.go`. Previously, `withings-export auth refresh` passed `refresh` as a positional arg to `RunE`, which silently printed help and exited 0. With `cobra.NoArgs`, Cobra validates arguments before calling `RunE`, rejecting any positional args and exiting non-zero with an error.

Fixes #31.

Generated with [Claude Code](https://claude.ai/code)