### PR TITLE
Wire §4 conformance test against compat/formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: go vet + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: go vet
+        run: go vet ./...
+      - name: go test
+        run: go test ./...
+
+  compat:
+    name: compat (CONTRACT machine-attestation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: resolve compat dependency
+        # The compat module lives at github.com/quantcli/common/compat
+        # under a subpath. `go mod tidy` materializes go.sum for it on
+        # first run; subsequent runs are cache-served.
+        run: go mod tidy
+      - name: build withings-export
+        run: go build -o /tmp/withings-export .
+      - name: run compat suite
+        env:
+          # Path the compat-tagged test reads from os.Getenv.
+          WITHINGS_EXPORT_BIN: /tmp/withings-export
+        run: go test -tags=compat -run TestContractFormats ./...

--- a/compat_contract_test.go
+++ b/compat_contract_test.go
@@ -1,0 +1,114 @@
+//go:build compat
+
+// Compat-test entry point for withings-export-cli.
+//
+// This file is only compiled under the `compat` build tag, so it does
+// not affect the default `go test ./...` run. CI invokes it as
+// `go test -tags=compat ./...` after building the export binary and
+// exposing its path through WITHINGS_EXPORT_BIN.
+//
+// The actual assertions live in github.com/quantcli/common/compat.
+// Drift between this CLI and CONTRACT.md surfaces as a failure here.
+package main_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/quantcli/common/compat"
+	"github.com/quantcli/common/compat/formats"
+)
+
+func TestContractFormats(t *testing.T) {
+	bin := os.Getenv("WITHINGS_EXPORT_BIN")
+	if bin == "" {
+		t.Skip("WITHINGS_EXPORT_BIN not set; skipping compat suite")
+	}
+
+	// withings's data path requires a usable OAuth token plus a
+	// reachable Withings API origin, neither of which a clean CI
+	// runner has. We stand up a stub that returns the empty Withings
+	// envelope to every POST and write a never-expired token into a
+	// scratch HOME so auth.GetToken returns without touching the
+	// network. The binary picks up the stub origin via
+	// WITHINGS_API_BASE (added in internal/client) and the token via
+	// the existing HOME-rooted config path.
+	stub := newWithingsStub()
+	t.Cleanup(stub.Close)
+	home := writeFakeAuthToken(t)
+
+	formats.RunContract(t, compat.Runner{
+		Binary: bin,
+		// withings is cobra-based: --format lives on each
+		// data-producing subcommand. The compat suite dispatches per
+		// subcommand under a `subcommand=NAME/...` subtree so any
+		// regression surfaces as a named subtest failure rather than
+		// masking the rest.
+		Subcommands: []string{
+			"activity",
+			"intraday",
+			"measurements",
+			"sleep",
+			"workouts",
+		},
+		Env: []string{
+			"HOME=" + home,
+			"PATH=/usr/bin:/bin",
+			"TZ=UTC",
+			"WITHINGS_API_BASE=" + stub.URL,
+		},
+	})
+}
+
+// newWithingsStub returns an httptest.Server that answers every POST
+// with the Withings success envelope and an empty body. The Withings
+// shape is `{"status":0,"body":{…}}`; an empty body satisfies each
+// subcommand's response struct (slice fields stay nil, `more` stays
+// false, the pagination loop exits on the first call), so every codec
+// renders the empty-result form: `--format json` → `[]`, `--format csv`
+// → a header line, default and `--format markdown` → byte-identical
+// (empty) stdout. The stub does not validate the Authorization header —
+// the fake token below is just a placeholder so the auth layer reaches
+// the HTTP call rather than short-circuiting at `not logged in`.
+func newWithingsStub() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":0,"body":{}}`))
+	}))
+}
+
+// writeFakeAuthToken seeds a synthetic, never-expired token store at
+// HOME/.config/withings-export/auth.json so auth.GetToken returns a
+// usable string and the binary proceeds to the HTTP path. Returns the
+// HOME directory to set in Runner.Env.
+func writeFakeAuthToken(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "withings-export")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	token := map[string]any{
+		"access_token":  "compat-fake-access-token",
+		"refresh_token": "compat-fake-refresh-token",
+		// Far enough in the future that auth.GetToken takes the
+		// not-expired branch on every invocation.
+		"expires_at":    time.Now().AddDate(10, 0, 0).Format(time.RFC3339),
+		"user_id":       "0",
+		"client_id":     "compat-fake-client-id",
+		"client_secret": "compat-fake-client-secret",
+	}
+	body, err := json.MarshalIndent(token, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal fake token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), body, 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	return home
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/quantcli/withings-export-cli
 
 go 1.25.5
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/quantcli/common/compat v0.0.0-20260511001927-62c4c6634ff5
+	github.com/spf13/cobra v1.10.2
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/quantcli/common/compat v0.0.0-20260511001927-62c4c6634ff5 h1:NoWh40ITAC6W7YyIp2eM6RyRKLHzXcs8TXUjwoYrlUY=
+github.com/quantcli/common/compat v0.0.0-20260511001927-62c4c6634ff5/go.mod h1:VBC/zEphSZgCZS1rhWsR3A8EWYSbTkP/MwqWHL7266s=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/quantcli/withings-export-cli/internal/auth"
@@ -18,8 +19,16 @@ type Client struct {
 	baseURL string
 }
 
+// New returns a client pointed at Withings' production API. Setting
+// WITHINGS_API_BASE redirects requests to that origin instead — used by
+// the compat-test fixture to point the binary at a stub server so the
+// §4 data-path subtests can run without live OAuth.
 func New() *Client {
-	return &Client{http: &http.Client{}, baseURL: BaseURL}
+	base := BaseURL
+	if v := strings.TrimSpace(os.Getenv("WITHINGS_API_BASE")); v != "" {
+		base = strings.TrimRight(v, "/")
+	}
+	return &Client{http: &http.Client{}, baseURL: base}
 }
 
 // Call posts form-encoded params to a Withings API path and decodes the `body` field


### PR DESCRIPTION
Closes [QUA-17](https://github.com/quantcli/common/blob/main/CONTRACT.md). Onboards `withings-export-cli` as the third consumer of `compat/formats` (after [QUA-14](/QUA/issues/QUA-14) for crono dates and [QUA-21](/QUA/issues/QUA-21) for the bundle/affordance landings), so the §4 row in CONTRACT.md flips to **machine** for withings on merge.

## Summary

- `internal/client`: new `WITHINGS_API_BASE` env override on `client.New()` — when set, all `c.Call(...)` requests go to that origin instead of `https://wbsapi.withings.net`. Unset (default) keeps the production behavior.
- `compat_contract_test.go` (build tag `compat`): runs `formats.RunContract` against the binary with `compat.Runner.Subcommands` for all five data subcommands (`activity`, `intraday`, `measurements`, `sleep`, `workouts`). The test fixture stands up an `httptest.Server` that answers every POST with the empty Withings envelope `{"status":0,"body":{}}` and seeds a synthetic never-expired token at `$HOME/.config/withings-export/auth.json` so the binary's auth layer reaches the HTTP path without short-circuiting on `not logged in`.
- `.github/workflows/ci.yml`: new workflow mirroring `crono-export-cli`'s shape — a `go vet + test` job and a `compat (CONTRACT machine-attestation)` job that builds the binary, points `WITHINGS_EXPORT_BIN` at it, and runs `go test -tags=compat -run TestContractFormats ./...`.
- `go.mod`: pins `github.com/quantcli/common/compat` to `v0.0.0-20260511001927-62c4c6634ff5` — the post-QUA-21 pseudo-version that includes `Runner.SupportedFormats`. Withings implements all three §4 codecs so the runner declares the full surface (`SupportedFormats: nil`); the partial-codec skip path is exercised by `crono-export-cli` and `liftoff-export-cli` in their sibling PRs.

## Why the stub-server fixture

CONTRACT §4 requires `--format json` to emit a JSON array, `--format csv` to emit at least a header row, and the default to be byte-identical to `--format markdown`. The `compat/formats` bundle's `JSONIsArray`, `CSVHasHeader`, and `DefaultIsMarkdown` subtests invoke the binary against its real data path to attest these. Withings' data path requires a usable OAuth token plus a reachable Withings API origin — neither of which a clean CI runner has. The package docstring is explicit: *"Exporters whose data path is not yet runnable from a clean CI environment should wire the bundle in once it is — the parse-time subtests alone are not enough to claim machine attestation for §4."*

Setting `SupportedFormats: []string{}` to disable the data-path subtests would lie about withings' surface (it does implement all three codecs) and is the misuse the README warns against. The stub-server approach is the smallest honest path: a one-line env hook in `client.go` plus a self-contained `httptest.Server` in the compat test. No persistent or secret credentials added to CI.

## Local verification

```
$ go vet ./...        # clean
$ go vet -tags=compat ./...   # clean
$ go test ./...       # internal/auth tests pass; no other regressions
$ go build -o /tmp/withings-export .
$ WITHINGS_EXPORT_BIN=/tmp/withings-export go test -tags=compat -run TestContractFormats -v ./...
=== RUN   TestContractFormats
=== RUN   TestContractFormats/subcommand=activity
... (30 subtests: 5 subcommands × 6 assertions)
--- PASS: TestContractFormats (0.15s)
PASS
ok  	github.com/quantcli/withings-export-cli	0.151s
```

All six assertions (`HelpDocumentsFormatFlag`, `UnknownFormatFails`, `FlagValidationIsHermetic`, `JSONIsArray`, `CSVHasHeader`, `DefaultIsMarkdown`) pass for each of the five subcommands.

## Follow-ups (not blocking this PR)

- `quantcli/common/CONTRACT.md` §4 status row: flip withings' `--format markdown / json / csv` cells from `human` to **machine** on merge. Will file as a small follow-up PR in `common` once this lands.
- Withings currently calls the API before validating `--format`, so an unknown value reaches the network (the fixture absorbs it, but it is a §4-spirit violation that `flagValidationIsHermetic` does not currently catch). Worth a separate small PR moving `validateFormat()` to the top of each subcommand's `RunE`. Filing as a child if [LeadGoEngineer](https://github.com/Terastar-Paperclip) agrees.
- The same stub-server pattern is the unblock path for [QUA-16](/QUA/issues/QUA-16) (liftoff) and [QUA-19](/QUA/issues/QUA-19) (crono) once they wire `compat/formats`. Both are partial-codec (no CSV) so they will declare `SupportedFormats: []string{"markdown", "json"}`.

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test ./...` clean (no regression to existing `internal/auth` tests).
- [x] `go test -tags=compat -run TestContractFormats ./...` green with `WITHINGS_EXPORT_BIN` set (30/30 subtests pass).
- [ ] CI `go vet + test` job green.
- [ ] CI `compat (CONTRACT machine-attestation)` job green.
- [ ] [@LeadGoEngineer](https://github.com/Terastar-Paperclip) review pass.

🤖 Generated with [Paperclip](https://paperclip.ing)