### PR TITLE
chore(ci): add security.yml version marker

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,8 @@
+# security.yml v1 — source of truth: quantcli/common; sync changes to every *-export-cli.
+# Bump the version when this workflow changes materially; a future drift-check job will key off it.
+# See quantcli/common CONTRIBUTING.md "Supply-chain and security" for the propagation policy and
+# the >5-repos switchover trigger to a reusable workflow_call.
+
 name: security
 
 # Supply-chain and license-policy gate for quantcli repos.


### PR DESCRIPTION
## Summary

Follow-up from [Lead Go Engineer review on quantcli/common#5](https://github.com/quantcli/common/pull/5#pullrequestreview-4260001530). The security workflow is copy-and-propagated across repos today; this PR adds the version-marker comment at the top of `.github/workflows/security.yml` so a future drift-check job has a stable key to bind to. No behavior change to the workflow itself.

Mirrors [quantcli/common#21](https://github.com/quantcli/common/pull/21), which lands the same marker in `common` plus the propagation/switchover documentation in `CONTRIBUTING.md`.

## What changed

- `.github/workflows/security.yml`: 4-line marker prepended above `name:` (kept the existing 3-line block intact — those are propagation hints, the marker is the version key).

## Why

- The security workflow runs in `common` and every `*-export-cli`. Without a version marker there is no anchor for a future drift-check job that compares each export-cli's copy against `common`'s copy.
- The `>5-repos → workflow_call` switchover trigger is documented in `quantcli/common`'s `CONTRIBUTING.md`. This PR aligns the file's header with that policy.

## Test plan

- [ ] CI green (security workflow runs).
- [ ] Diff is comment-only — no behavior change in the workflow.

Refs QUA-47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)