### PR TITLE
chore(security): extend license allowlist with BSL-1.0, CC0-1.0, 0BSD

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -94,8 +94,9 @@ jobs:
       contents: read
     env:
       # Policy: every direct + transitive Go dep must resolve to one of these SPDX ids.
+      # Keep this list sorted by SPDX id; SECURITY.md "License allowlist" must match exactly.
       # See SECURITY.md "Supply-chain policy" for the rationale.
-      ALLOWED_LICENSES: "Apache-2.0,MIT,BSD-2-Clause,BSD-3-Clause,MPL-2.0,ISC,Unlicense"
+      ALLOWED_LICENSES: "0BSD,Apache-2.0,BSD-2-Clause,BSD-3-Clause,BSL-1.0,CC0-1.0,ISC,MIT,MPL-2.0,Unlicense"
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
## Summary

Mirrors [`quantcli/common#22`](https://github.com/quantcli/common/pull/22) (QUA-46). The `security` workflow is copied verbatim across repos today; this PR brings the per-repo copy in lockstep with the source of truth.

- Adds `0BSD`, `BSL-1.0` (Boost — **not** the source-available Business Source License), and `CC0-1.0` to `ALLOWED_LICENSES` in `.github/workflows/security.yml`.
- Re-orders the allowlist to ASCII-sorted by SPDX id and pins the ordering with a comment, so the workflow env and `common`'s `SECURITY.md` stay in sync on future edits.

The new entries are a strict superset of the previous list; no existing dep in this repo regresses.

For the rationale, the explicit `BSL-1.0` vs `BUSL-*` distinction, and the documented policy, see the companion PR on `quantcli/common`.

## Test plan

- [ ] CI green on this PR (govulncheck, osv-scanner, license-policy all pass).
- [ ] `ALLOWED_LICENSES` line matches `quantcli/common`'s exactly after both PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)