### PR TITLE
fix(cmd): validate --format before any network call (CONTRACT §4 spirit)

### DIFF
--- a/cmd/activity.go
+++ b/cmd/activity.go
@@ -49,6 +49,12 @@ var activityCmd = &cobra.Command{
 	Use:   "activity",
 	Short: "Export daily activity (steps, distance, calories, HR zones)",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Parse-level flag validation runs before any network call so an
+		// invalid --format exits non-zero hermetically (CONTRACT §4).
+		format, err := validateFormat(activityFormatFlag)
+		if err != nil {
+			return err
+		}
 		since, err := sinceOrDefault(activitySinceFlag, 30)
 		if err != nil {
 			return err
@@ -83,10 +89,6 @@ var activityCmd = &cobra.Command{
 
 		sort.Slice(all, func(i, j int) bool { return all[i].Date < all[j].Date })
 
-		format, err := validateFormat(activityFormatFlag)
-		if err != nil {
-			return err
-		}
 		switch format {
 		case "json":
 			return printJSON(all)

--- a/cmd/intraday.go
+++ b/cmd/intraday.go
@@ -69,6 +69,12 @@ spo2_auto, steps and distance; native Withings trackers report steps and HR.
 
 Default window is the last 24h — intraday is dense; wider ranges are slow.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Parse-level flag validation runs before any network call so an
+		// invalid --format exits non-zero hermetically (CONTRACT §4).
+		format, err := validateFormat(intradayFormatFlag)
+		if err != nil {
+			return err
+		}
 		since, err := sinceOrDefault(intradaySinceFlag, 1)
 		if err != nil {
 			return err
@@ -124,10 +130,6 @@ Default window is the last 24h — intraday is dense; wider ranges are slow.`,
 
 		sort.Slice(all, func(i, j int) bool { return all[i].Timestamp < all[j].Timestamp })
 
-		format, err := validateFormat(intradayFormatFlag)
-		if err != nil {
-			return err
-		}
 		switch format {
 		case "json":
 			return printJSON(all)

--- a/cmd/measurements.go
+++ b/cmd/measurements.go
@@ -80,6 +80,12 @@ var measurementsCmd = &cobra.Command{
 	Use:   "measurements",
 	Short: "Export body measurements (weight, body fat, BP, etc.)",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Parse-level flag validation runs before any network call so an
+		// invalid --format exits non-zero hermetically (CONTRACT §4).
+		format, err := validateFormat(measurementsFormatFlag)
+		if err != nil {
+			return err
+		}
 		since, err := sinceOrDefault(measurementsSinceFlag, 30)
 		if err != nil {
 			return err
@@ -131,10 +137,6 @@ var measurementsCmd = &cobra.Command{
 
 		sort.Slice(rows, func(i, j int) bool { return rows[i].Date.Before(rows[j].Date) })
 
-		format, err := validateFormat(measurementsFormatFlag)
-		if err != nil {
-			return err
-		}
 		switch format {
 		case "json":
 			return printJSON(rows)

--- a/cmd/sleep.go
+++ b/cmd/sleep.go
@@ -44,6 +44,12 @@ var sleepCmd = &cobra.Command{
 	Use:   "sleep",
 	Short: "Export nightly sleep summaries",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Parse-level flag validation runs before any network call so an
+		// invalid --format exits non-zero hermetically (CONTRACT §4).
+		format, err := validateFormat(sleepFormatFlag)
+		if err != nil {
+			return err
+		}
 		since, err := sinceOrDefault(sleepSinceFlag, 30)
 		if err != nil {
 			return err
@@ -110,10 +116,6 @@ var sleepCmd = &cobra.Command{
 
 		sort.Slice(all, func(i, j int) bool { return all[i].StartDate < all[j].StartDate })
 
-		format, err := validateFormat(sleepFormatFlag)
-		if err != nil {
-			return err
-		}
 		switch format {
 		case "json":
 			return printJSON(all)

--- a/cmd/workouts.go
+++ b/cmd/workouts.go
@@ -95,6 +95,12 @@ var workoutsCmd = &cobra.Command{
 	Use:   "workouts",
 	Short: "Export workouts (runs, walks, bikes, etc.)",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Parse-level flag validation runs before any network call so an
+		// invalid --format exits non-zero hermetically (CONTRACT §4).
+		format, err := validateFormat(workoutsFormatFlag)
+		if err != nil {
+			return err
+		}
 		since, err := sinceOrDefault(workoutsSinceFlag, 90)
 		if err != nil {
 			return err
@@ -131,10 +137,6 @@ var workoutsCmd = &cobra.Command{
 
 		sort.Slice(all, func(i, j int) bool { return all[i].StartDate < all[j].StartDate })
 
-		format, err := validateFormat(workoutsFormatFlag)
-		if err != nil {
-			return err
-		}
 		switch format {
 		case "json":
 			return printJSON(all)


### PR DESCRIPTION
Closes QUA-30. Follow-up to #36.

## Why

PR #36 wired `withings-export-cli` into `compat/formats`, including the `flagValidationIsHermetic` subtest. It passed, but for the wrong reason: each data-producing subcommand's `RunE` called `client.New()` and the Withings HTTP path **before** `validateFormat()`. Under the compat test's `HTTP_PROXY=127.0.0.1:1` env that HTTP round-trip failed with a dial-timeout, so the binary exited non-zero — making the subtest happy even though it never proved a parse-time failure was network-free.

The contract's §4 spirit (and the framework comment on the subtest) is "a flag-validation failure must not have already opened a connection by the time it exits non-zero." Today's withings behavior violates that. This PR closes the gap.

## What

In each of `cmd/{activity,intraday,measurements,sleep,workouts}.go`, the first statement of `RunE` is now:

```go
format, err := validateFormat(<sub>FormatFlag)
if err != nil {
    return err
}
```

The previous late-binding `validateFormat` call near the codec switch is removed; the `format` variable from the top is reused there. No other logic moves. No new dependencies. No changes to flag declarations, output shapes, or the help string.

## Acceptance check (per the QUA-30 description)

Built the binary and ran every data-producing subcommand under the same no-network proxy env the compat suite uses:

```
HTTP_PROXY=http://127.0.0.1:1 HTTPS_PROXY=http://127.0.0.1:1
http_proxy=http://127.0.0.1:1 https_proxy=http://127.0.0.1:1
NO_PROXY= no_proxy= TZ=UTC HOME=<empty>
./withings-export <sub> --format obviously-not-a-format
```

Every subcommand now exits with:

- exit code `1`
- empty stdout (§4 "stdout is data only")
- stderr `Error: unknown --format "obviously-not-a-format" (use markdown, json, or csv)`

No dial-timeout error, no auth error — the parse fails first and that's all that runs.

Local `go test -tags=compat -run TestContractFormats ./...` still green: all 30 subtests (6 contract subtests × 5 subcommands) PASS, including the now-genuinely-hermetic `FlagValidationIsHermetic`. `go vet ./...` and `go test ./...` clean.

## Re: the optional WITHINGS_API_BASE drop

The QUA-30 description proposed optionally dropping `WITHINGS_API_BASE` from the compat-test runner once parse failure was hermetic. Skipping that here — the happy-path subtests (`JSONIsArray`, `CSVHasHeader`, `DefaultIsMarkdown`) run the binary without `HTTP_PROXY` override, and they still need the stub origin via `WITHINGS_API_BASE` to reach a successful HTTP response. Removing it would break the data-path subtests. The hermetic claim is now enforced at the code level by the validate-first ordering, not by the env shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)